### PR TITLE
Gitignore update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+node_modules/


### PR DESCRIPTION
I noticed that a lot of students were committing node_modules when they are submitting studios.
Adding `node_modules/` to .gitignore in the root directory will prevent that from happening.

Before adding `node_modules` to .gitignore

<img width="632" alt="image" src="https://github.com/LaunchCodeEducation/javascript-projects/assets/34907404/95d886ae-20ee-4b30-9bc3-afdaeb15a024">

Aftere adding `node_modules` to .gitignore

<img width="593" alt="image" src="https://github.com/LaunchCodeEducation/javascript-projects/assets/34907404/3fc730a5-5c50-46e7-9c3b-5674dcebbe34">
